### PR TITLE
Fix Achievement_DeathMicro

### DIFF
--- a/addons/sourcemod/scripting/scp_sf.sp
+++ b/addons/sourcemod/scripting/scp_sf.sp
@@ -139,6 +139,7 @@ enum struct ClientEnum
 	int Disarmer;
 	int DownloadMode;
 	int BadKills;
+	int PreDamageWeapon;
 
 	float IdleAt;
 	float ComFor;
@@ -1886,7 +1887,7 @@ public Action OnPlayerDeath(Event event, const char[] name, bool dontBroadcast)
 			if(damage & DMG_SHOCK)
 			{
 				GiveAchievement(Achievement_DeathTesla, client);
-				int wep = GetEntPropEnt(client, Prop_Send, "m_hActiveWeapon");
+				int wep = EntRefToEntIndex(Client[client].PreDamageWeapon);
 				if(wep>MaxClients && GetEntProp(wep, Prop_Send, "m_iItemDefinitionIndex")==594)
 					GiveAchievement(Achievement_DeathMicro, client);
 			}

--- a/addons/sourcemod/scripting/scp_sf/sdkhooks.sp
+++ b/addons/sourcemod/scripting/scp_sf/sdkhooks.sp
@@ -343,6 +343,10 @@ public Action OnTakeDamage(int victim, int &attacker, int &inflictor, float &dam
 	if(!Enabled)
 		return Plugin_Continue;
 
+	int activeWeapon = GetEntPropEnt(victim, Prop_Send, "m_hActiveWeapon");
+	if (activeWeapon>MaxClients)
+		Client[victim].PreDamageWeapon = EntIndexToEntRef(activeWeapon);
+
 	bool validAttacker = IsValidClient(attacker);
 	if(validAttacker && victim!=attacker)
 	{


### PR DESCRIPTION
The `player_death` event fires too late to be able to fetch the client's active weapon. `m_hActiveWeapon` will always return `-1` in an event hook.

Instead, we save the weapon in a new client property `PreDamageWeapon` before the damage is applied, allowing other parts of the code to check against it.