### PR TITLE
Fix Achievement_KillMirco

### DIFF
--- a/addons/sourcemod/scripting/scp_sf.sp
+++ b/addons/sourcemod/scripting/scp_sf.sp
@@ -1840,6 +1840,13 @@ public Action OnPlayerDeath(Event event, const char[] name, bool dontBroadcast)
 		}
 		spreeFor[attacker] = engineTime+6.0;
 
+		if (IsSCP(attacker))
+		{
+			int wep = EntRefToEntIndex(Client[client].PreDamageWeapon);
+			if(wep>MaxClients && GetEntProp(wep, Prop_Send, "m_iItemDefinitionIndex")==594)
+				GiveAchievement(Achievement_KillMirco, client);
+		}
+
 		Classes_OnKill(attacker, client);
 
 		if(IsFriendly(Client[client].Class, Client[attacker].Class))

--- a/addons/sourcemod/scripting/scp_sf/classes.sp
+++ b/addons/sourcemod/scripting/scp_sf/classes.sp
@@ -924,13 +924,6 @@ public bool Classes_DeathScp(int client, Event event)
 	return true;
 }
 
-public void Classes_KillScp(int client, int victim)
-{
-	int wep = GetEntPropEnt(victim, Prop_Send, "m_hActiveWeapon");
-	if(wep>MaxClients && GetEntProp(wep, Prop_Send, "m_iItemDefinitionIndex")==594)
-		GiveAchievement(Achievement_KillMirco, client);
-}
-
 public void Classes_KillDBoi(int client, int victim)
 {
 	if(Classes_GetByName("sci") == Client[victim].Class)


### PR DESCRIPTION
`Classes_KillScp` is not used anywhere in config, and since several SCPs already used `func_kill` on other reasons, I'd suggest to just move code to main section.