### PR TITLE
Fix warnings from compiling without optional include

### DIFF
--- a/addons/sourcemod/scripting/scp_sf.sp
+++ b/addons/sourcemod/scripting/scp_sf.sp
@@ -89,8 +89,14 @@ enum ClassSpawnEnum
 bool Enabled = false;
 bool NoMusic = false;
 bool ChatHook = false;
+
+#if defined _sourcecomms_included
 bool SourceComms = false;		// SourceComms++
+#endif
+
+#if defined _basecomm_included
 bool BaseComm = false;		// BaseComm
+#endif
 
 MemoryPatch PatchProcessMovement;
 


### PR DESCRIPTION
If plugin were to be compiled without `sourcecomms` and/or `basecomm`, warnings were to be thrown
```
SCP: Secret Fortress(93) : warning 203: symbol is never used: "BaseComm"
SCP: Secret Fortress(92) : warning 203: symbol is never used: "SourceComms"
```