### PR TITLE
Fix download of MTF/Chaos spawn sounds

### DIFF
--- a/addons/sourcemod/scripting/scp_sf/gamemode.sp
+++ b/addons/sourcemod/scripting/scp_sf/gamemode.sp
@@ -810,7 +810,7 @@ static void KvGetSound(KeyValues kv, const char[] string, SoundEnum sound, const
 				sound.Time = 0.0;
 				strcopy(sound.Path, sizeof(sound.Path), buffers[0]);
 				if(sound.Path[0])
-					PrecacheSound(sound.Path, true);
+					PrecacheSoundEx(sound.Path, true);
 			}
 			case 2:
 			{
@@ -818,7 +818,7 @@ static void KvGetSound(KeyValues kv, const char[] string, SoundEnum sound, const
 				strcopy(sound.Path, sizeof(sound.Path), buffers[1]);
 				sound.Volume = 2;
 				if(sound.Path[0])
-					PrecacheSound(sound.Path, true);
+					PrecacheSoundEx(sound.Path, true);
 			}
 			default:
 			{
@@ -826,7 +826,7 @@ static void KvGetSound(KeyValues kv, const char[] string, SoundEnum sound, const
 				strcopy(sound.Path, sizeof(sound.Path), buffers[1]);
 				sound.Volume = StringToInt(buffers[2]);
 				if(sound.Path[0])
-					PrecacheSound(sound.Path, true);
+					PrecacheSoundEx(sound.Path, true);
 			}
 		}
 	}

--- a/addons/sourcemod/scripting/scp_sf/stocks.sp
+++ b/addons/sourcemod/scripting/scp_sf/stocks.sp
@@ -1004,9 +1004,21 @@ stock int PrecacheModelEx(const char[] model, bool preload=false)
 
 stock int PrecacheSoundEx(const char[] sound, bool preload=false)
 {
+	static const char soundchars[] = { '*', '#', '@', '>', '<', '^', ')', '}', '$' };
+
 	char buffer[PLATFORM_MAX_PATH];
+	strcopy(buffer, sizeof(buffer), sound);
+
+	for(int i=0; i<sizeof(soundchars); i++)
+	{
+		if(buffer[0] == soundchars[i])
+		{
+			strcopy(buffer, sizeof(buffer), sound[1]);
+			break;
+		}
+	}
+
 	FormatEx(buffer, sizeof(buffer), "sound/%s", sound);
-	ReplaceStringEx(buffer, sizeof(buffer), "#", "");
 	if(FileExists(buffer))
 		AddFileToDownloadsTable(buffer);
 


### PR DESCRIPTION
I am not sure if these sounds were originally supposed to be packed with the maps, but they are not. Since they are present in the global config and are uploaded to the repository already, I figured they should download.

I've also updated `PrecacheSoundEx` to support removing any sound characters.