### PR TITLE
Add lag compensation

### DIFF
--- a/addons/sourcemod/gamedata/scp_sf.txt
+++ b/addons/sourcemod/gamedata/scp_sf.txt
@@ -118,6 +118,28 @@
 				"return"	"void"
 				"this"		"entity"
 			}
+			"CBasePlayer::WantsLagCompensationOnEntity"
+			{
+				"offset"	"CBasePlayer::WantsLagCompensationOnEntity"
+				"hooktype"	"entity"
+				"return"	"bool"
+				"this"		"entity"
+				"arguments"
+				{
+					"pPlayer"
+					{
+						"type"	"cbaseentity"
+					}
+					"pCmd"
+					{
+						"type"	"objectptr"
+					}
+					"pEntityTransmitBits"
+					{
+						"type"	"objectptr"
+					}
+				}
+			}
 			"CTeamplayRoundBasedRules::RoundRespawn"
 			{
 				"offset"	"CTeamplayRoundBasedRules::RoundRespawn"
@@ -306,6 +328,11 @@
 			{
 				"linux"		"331"
 				"windows"	"330"
+			}
+			"CBasePlayer::WantsLagCompensationOnEntity"
+			{
+				"linux"		"329"
+				"windows"	"328"
 			}
 			"CTeamplayRoundBasedRules::RoundRespawn"
 			{

--- a/addons/sourcemod/scripting/scp_sf/dhooks.sp
+++ b/addons/sourcemod/scripting/scp_sf/dhooks.sp
@@ -92,6 +92,7 @@ void DHook_UnhookClient(int client)
 {
 	DynamicHook.RemoveHook(ForceRespawnPreHook[client]);
 	DynamicHook.RemoveHook(ForceRespawnPostHook[client]);
+	DynamicHook.RemoveHook(WantsLagCompensationOnEntityPreHook[client]);
 	DynamicHook.RemoveHook(WantsLagCompensationOnEntityPostHook[client]);
 }
 


### PR DESCRIPTION
Upon a lag compensation check issued by the game, we switch the players into different teams in the pre-hook so that the "different team" checks in `CBasePlayer::WantsLagCompensationOnEntity` always evaluate to `true`, but the angle checks further down the line don't.

Then, if the function still wants lag compensation, our post hook gets called and has the final say whether it should actually go through with a simple `IsFriendly` check, along with moving the clients back to their original teams.

This has no significant performance impact.