### PR TITLE
Switch ShouldCollide from SDKHook to DHook

### DIFF
--- a/addons/sourcemod/gamedata/scp_sf.txt
+++ b/addons/sourcemod/gamedata/scp_sf.txt
@@ -111,6 +111,24 @@
 					}
 				}
 			}
+			"CBaseEntity::ShouldCollide"
+			{
+				"offset"	"CBaseEntity::ShouldCollide"
+				"hooktype"	"entity"
+				"return"	"bool"
+				"this"		"entity"
+				"arguments"
+				{
+					"collisionGroup"
+					{
+						"type"	"int"
+					}
+					"contentsMask"
+					{
+						"type"	"int"
+					}
+				}
+			}
 			"CBasePlayer::ForceRespawn"
 			{
 				"offset"	"CBasePlayer::ForceRespawn"
@@ -318,6 +336,11 @@
 			{
 				"linux" 	"6"
 				"windows" 	"5"
+			}
+			"CBaseEntity::ShouldCollide"
+			{
+				"linux"		"17"
+				"windows"	"16"
 			}
 			"CBasePlayer::EquipWearable"
 			{

--- a/addons/sourcemod/scripting/scp_sf/sdkhooks.sp
+++ b/addons/sourcemod/scripting/scp_sf/sdkhooks.sp
@@ -9,7 +9,6 @@ void SDKHook_HookClient(int client)
 	SDKHook(client, SDKHook_OnTakeDamage, OnTakeDamage);
 	SDKHook(client, SDKHook_OnTakeDamageAlive, OnTakeDamageAlive);
 	SDKHook(client, SDKHook_SetTransmit, OnTransmit);
-	SDKHook(client, SDKHook_ShouldCollide, OnShouldCollide);
 	SDKHook(client, SDKHook_WeaponSwitchPost, OnWeaponSwitch);
 	SDKHook(client, SDKHook_PostThink, OnPostThink);
 	SDKHook(client, SDKHook_PostThinkPost, OnPostThinkPost);
@@ -328,14 +327,6 @@ public Action OnPipeSpawned(int entity)
 public Action OnPipeTouch(int entity, int client)
 {
 	return IsValidClient(client) ? Plugin_Handled : Plugin_Continue;
-}
-
-public bool OnShouldCollide(int client, int collisiongroup, int contentsmask, bool original)
-{
-	if(collisiongroup == COLLISION_GROUP_PLAYER_MOVEMENT)
-		return false;
-
-	return original;
 }
 
 public Action OnTakeDamage(int victim, int &attacker, int &inflictor, float &damage, int &damagetype, int &weapon, float damageForce[3], float damagePosition[3], int damagecustom)


### PR DESCRIPTION
SDKHook currently have issues with `ShouldCollide` hook causing everyone not able to damage eachother, and apparently doesn't affect all servers? it's weird. Ditch SDKHook and use DHook instead.