### PR TITLE
Fix "RNG" during class assignment

### DIFF
--- a/addons/sourcemod/scripting/scp_sf.sp
+++ b/addons/sourcemod/scripting/scp_sf.sp
@@ -126,6 +126,7 @@ enum struct ClientEnum
 	int Class;
 	int Colors[4];
 	int ColorBlind[3];
+	int QueueIndex;
 
 	bool IsVip;
 	bool CanTalkTo[MAXTF2PLAYERS];
@@ -471,6 +472,7 @@ public void OnPluginEnd()
 public void OnClientPutInServer(int client)
 {
 	Client[client] = Client[0];
+	Gamemode_AssignQueueIndex(client);
 	if(AreClientCookiesCached(client))
 		OnClientCookiesCached(client);
 
@@ -1783,6 +1785,7 @@ public Action Command_ForceAmmo(int client, int args)
 
 public void OnClientDisconnect(int client)
 {
+	Gamemode_UnassignQueueIndex(client);
 	SZF_DropItem(client);
 	CreateTimer(1.0, CheckAlivePlayers, _, TIMER_FLAG_NO_MAPCHANGE);
 }

--- a/addons/sourcemod/scripting/scp_sf.sp
+++ b/addons/sourcemod/scripting/scp_sf.sp
@@ -245,6 +245,7 @@ public void OnPluginStart()
 	Client[0].ColorBlind[0] = -1;
 	Client[0].ColorBlind[1] = -1;
 	Client[0].ColorBlind[2] = -1;
+	Client[0].QueueIndex = -1;
 
 	ConVar_Setup();
 	SDKHook_Setup();

--- a/addons/sourcemod/scripting/scp_sf/gamemode.sp
+++ b/addons/sourcemod/scripting/scp_sf/gamemode.sp
@@ -44,14 +44,14 @@ static int TeamColors[][] =
 	{ 139, 0, 0, 255 }
 };
 
-static int GameSortSeed;
+static int PlayerArrayOffset;
 static Handle WaveTimer;
 static Function GameCondition;
 static Function GameRoundStart;
 static StringMap GameInfo;
 
 static int PlayerQueue[MAXTF2PLAYERS];
-static int MaxQueueIndex;
+static int MaxQueueIndex = -1;
 
 static ArrayList Presets;
 static ArrayList SetupList;
@@ -278,51 +278,57 @@ bool Gamemode_RoundStart()
 	}
 
 	// This was done to prevent RNG just being funky against repeating classes
-	if(!GameSortSeed)
+	if(!PlayerArrayOffset)
 	{
-		GameSortSeed = GetRandomInt(1, MaxClients);
-	}
-	else
-	{
-		int players;
-		for(int client=1; client<=MaxClients; client++)
+		int players = 0;
+
+		for (int client = 1; client <= MaxClients; client++)
 		{
 			if(IsClientInGame(client) && GetClientTeam(client)>view_as<int>(TFTeam_Spectator))
 				players++;
 		}
+		
+		PlayerArrayOffset = GetRandomInt(0, players);
+	}
+	else
+	{
+		PlayerArrayOffset = 1;
+	}
 
-		if(++GameSortSeed > players)
-			GameSortSeed = 1;
+	// Shift queue indices
+	int start = PlayerArrayOffset;
+	int[] clientBuffer = new int[MaxClients]; // We'll add those clients to the end of the queue
+	for(int i = 0, j; PlayerQueue[i] != 0; i++)
+	{
+		if(i < start)
+		{
+			clientBuffer[j++] = PlayerQueue[i];
+		}
+		else
+		{
+			int client = PlayerQueue[i];
+			Client[client].QueueIndex = i - start;
+			PlayerQueue[Client[client].QueueIndex] = client;
+			PlayerQueue[i] = 0;
+		}
+	}
+
+	// Add clients from clientBuffer back to the queue;
+	for(int i = MaxQueueIndex - (PlayerArrayOffset - 1), j; i <= MaxQueueIndex; i++)
+	{
+		int client = clientBuffer[j++];
+		Client[client].QueueIndex = i;
+		PlayerQueue[Client[client].QueueIndex] = client;
 	}
 
 	ArrayList players = new ArrayList();
 
-	// Reduce everyone's queue index by 1
-	// Client with the index 0 will get maxIndex instead
-	int firstIndexClient;
-	for (int client = 1; client <= MaxClients; client++)
-	{
-		if (IsValidClient(client))
-		{
-			if (Client[client].QueueIndex > 0)
-			{
-				--Client[client].QueueIndex;
-				PlayerQueue[Client[client].QueueIndex] = client;
-			}
-			else if (Client[client].QueueIndex == 0)
-			{
-				Client[client].QueueIndex = MaxQueueIndex;
-				firstIndexClient = client;
-			}
-		}
-	}
-	PlayerQueue[MaxQueueIndex] = firstIndexClient;
-
-	for (int i = 0; i < MAXTF2PLAYERS; i++)
+	// Fill the players ArrayList
+	for(int i = 0; PlayerQueue[i] != 0; i++)
 	{
 		int client = PlayerQueue[i];
 
-		if(IsValidClient(client) && GetClientTeam(client)>view_as<int>(TFTeam_Spectator))
+		if(GetClientTeam(client)>view_as<int>(TFTeam_Spectator))
 		{
 			Client[client].NextSongAt = 0.0;
 			players.Push(client);
@@ -353,7 +359,6 @@ bool Gamemode_RoundStart()
 		static char buffer[16];
 		if(Classes_GetByIndex(Client[client].Class, class))
 		{
-			//LogMessage("(%i|%i) %N: %s", client, Client[client].QueueIndex, client, class.Name);
 			strcopy(buffer, sizeof(buffer), class.Name);
 			switch(Forward_OnClassPre(client, ClassSpawn_RoundStart, buffer, sizeof(buffer)))
 			{


### PR DESCRIPTION
Class assignment in `Gamemode_RoundStart()` used to assign classes to players according to `"setup"` in `gamemode.cfg`: if `GameSortSeed` is set to 0, client 1 will be class-d, client 3 will be a scientist, and so on.
After a round `GameSortSeed` gets incremented and players *should* get the class above the one they've had before, however, this does not take into account the fact that client indices are reusable, which means people will play as the class they've had before if a lesser client index becomes taken by a newly connected client.

This PR fixes this issue by giving each client a queue index which is based on the order of connection of the client.
Newly connected clients will always be at the end of the queue, and the `PlayerQueue` array is shifted upon client disconnect.
`GameSortSeed` is replaced with `PlayerArrayOffset`, which defines by how much the `PlayerQueue` array should be shifted during class assignment, it's set to a random number in the first round and is set to 1 for all consecutive ones.