### PR TITLE
Update list of SCPs in scp_fortress

### DIFF
--- a/addons/sourcemod/configs/scp_sf/maps/scp_fortress.cfg
+++ b/addons/sourcemod/configs/scp_sf/maps/scp_fortress.cfg
@@ -18,12 +18,13 @@
 			"10"	"mtf2"
 			"11"	"mtfs"
 			"12"	"mtf3"
-			"13"	"scp096"
-			"14"	"scp106"
-			"15"	"scp173"
-			"16"	"scp457"
-			"17"	"scp939"
-			"18"	"scp9392"
+			"13"	"scp049"
+			"14"	"scp0492"
+			"15"	"scp096"
+			"16"	"scp106"
+			"17"	"scp173"
+			"18"	"scp939"
+			"19"	"scp9392"
 		}
 
 		"setup"	// Goes up to 32 players
@@ -141,13 +142,12 @@
 			"set_scp"
 			{
 				"type"	"Gamemode_PresetRandomOnce"	// Only one of this class alive
-				"1"	"scp076"
+				"1"	"scp049"
 				"2"	"scp096"
 				"3"	"scp106"
 				"4"	"scp173"
-				"5"	"scp457"
-				"6"	"scp939"
-				"7"	"scp9392"
+				"5"	"scp939"
+				"6"	"scp9392"
 			}
 			"set_mtf"
 			{

--- a/addons/sourcemod/configs/scp_sf/maps/scp_fortress.cfg
+++ b/addons/sourcemod/configs/scp_sf/maps/scp_fortress.cfg
@@ -18,13 +18,11 @@
 			"10"	"mtf2"
 			"11"	"mtfs"
 			"12"	"mtf3"
-			"13"	"scp049"
-			"14"	"scp0492"
-			"15"	"scp096"
-			"16"	"scp106"
-			"17"	"scp173"
-			"18"	"scp939"
-			"19"	"scp9392"
+			"13"	"scp096"
+			"14"	"scp106"
+			"15"	"scp173"
+			"16"	"scp939"
+			"17"	"scp9392"
 		}
 
 		"setup"	// Goes up to 32 players
@@ -142,12 +140,11 @@
 			"set_scp"
 			{
 				"type"	"Gamemode_PresetRandomOnce"	// Only one of this class alive
-				"1"	"scp049"
-				"2"	"scp096"
-				"3"	"scp106"
-				"4"	"scp173"
-				"5"	"scp939"
-				"6"	"scp9392"
+				"1"	"scp096"
+				"2"	"scp106"
+				"3"	"scp173"
+				"4"	"scp939"
+				"5"	"scp9392"
 			}
 			"set_mtf"
 			{


### PR DESCRIPTION
scp049 spawnpoint exists in map but was never used. Also scp076 and scp457 exists in config, but don't have spawnpoint, which causes scp457 to spawn at chaos spawnpoint instead.