### PR TITLE
Add native SCPSF_GetChatTag

### DIFF
--- a/addons/sourcemod/scripting/include/scp_sf.inc
+++ b/addons/sourcemod/scripting/include/scp_sf.inc
@@ -105,6 +105,18 @@ native void SCPSF_StopMusic(int client=0);
 native bool SCPSF_CanTalkTo(int client, int target);
 
 /**
+ * Gets tag to display in client chat
+ *
+ * @param client 	Client index of speaker
+ * @param target 	Client index of listener
+ * @param buffer 	Buffer string to store
+ * @param length 	Max length of buffer
+ *
+ * @noreturn
+ */
+native void SCPSF_GetChatTag(int client, int target, char[] buffer, int length);
+
+/**
  * Calls when a specific event happens
  *
  * @param client 	Client index
@@ -218,5 +230,6 @@ public void __pl_SCPSF_SetNTVOptional()
 	MarkNativeAsOptional("SCPSF_StartMusic");
 	MarkNativeAsOptional("SCPSF_StopMusic");
 	MarkNativeAsOptional("SCPSF_CanTalkTo");
+	MarkNativeAsOptional("SCPSF_GetChatTag");
 }
 #endif

--- a/addons/sourcemod/scripting/scp_sf.sp
+++ b/addons/sourcemod/scripting/scp_sf.sp
@@ -1375,98 +1375,83 @@ public Action OnSayCommand(int client, const char[] command, int args)
 
 	Forward_OnMessage(client, name, sizeof(name), msg, sizeof(msg));
 
-	float engineTime = GetGameTime();
-
-	if(!Enabled)
+	if (Enabled)
 	{
-		for(int target=1; target<=MaxClients; target++)
+		#if SOURCEMOD_V_MAJOR==1 && SOURCEMOD_V_MINOR>10
+		Client[client].IdleAt = GetGameTime()+2.5;
+		#endif
+	}
+
+	for(int target=1; target<=MaxClients; target++)
+	{
+		if(target==client || (IsValidClient(target, false) && Client[client].CanTalkTo[target]))
 		{
-			if(target==client || (IsValidClient(target, false) && Client[client].CanTalkTo[target]))
+			if (Enabled)
+			{
+				if(!IsPlayerAlive(client) && GetClientTeam(client)<=view_as<int>(TFTeam_Spectator))
+				{
+					if (IsSpec(target))
+						Client[target].ThinkIsDead[client] = true;
+					else
+						continue;	//Don't show chat to target
+				}
+				else if(IsSpec(client))
+				{
+					if (!IsSpec(target))
+						continue;	//Don't show chat to target
+				}
+				else
+				{
+					Client[target].ThinkIsDead[client] = false;
+				}
+			}
+			
+			char tag[64];
+			GetClientChatTag(client, target, tag, sizeof(tag));
+			if (tag[0])
+				CPrintToChat(target, "%s %s {default}: %s", tag, name, msg);
+			else
 				CPrintToChat(target, "%s {default}: %s", name, msg);
 		}
 	}
+
+	return Plugin_Handled;
+}
+
+public void GetClientChatTag(int client, int target, char[] buffer, int length)
+{
+	if(!Enabled)
+	{
+		//No tag
+	}
 	else if(!IsPlayerAlive(client) && GetClientTeam(client)<=view_as<int>(TFTeam_Spectator))
 	{
-		for(int target=1; target<=MaxClients; target++)
-		{
-			if(target==client || (IsValidClient(target, false) && Client[client].CanTalkTo[target] && IsSpec(target)))
-			{
-				Client[target].ThinkIsDead[client] = true;
-				CPrintToChat(target, "*SPEC* %s {default}: %s", name, msg);
-			}
-		}
+		strcopy(buffer, length, "*SPEC*");
 	}
 	else if(IsSpec(client))
 	{
-		for(int target=1; target<=MaxClients; target++)
-		{
-			if(target==client || (IsValidClient(target, false) && Client[client].CanTalkTo[target] && IsSpec(target)))
-				CPrintToChat(target, "*DEAD* %s {default}: %s", name, msg);
-		}
+		strcopy(buffer, length, "*DEAD*");
 	}
-	else if(Client[client].ComFor > engineTime)
+	else if(Client[client].ComFor > GetGameTime())
 	{
-		for(int target=1; target<=MaxClients; target++)
-		{
-			if(target==client || (IsValidClient(target, false) && Client[client].CanTalkTo[target]))
-			{
-				Client[target].ThinkIsDead[client] = false;
-				CPrintToChat(target, "*COMM* %s {default}: %s", name, msg);
-			}
-		}
+		strcopy(buffer, length, "*INTERCOM*");
 	}
-	else
+	else if(!IsSpec(target))
 	{
-		#if SOURCEMOD_V_MAJOR==1 && SOURCEMOD_V_MINOR>10
-		Client[client].IdleAt = engineTime+2.5;
-		#endif
-
-		bool radio = Items_Radio(client)>1;
-
 		ClassEnum class;
-		if(!Classes_GetByIndex(Client[client].Class, class))
-			class.Human = true;	// If we somehow have an invalid class, atleast prevent errors
-
-		static float clientPos[3];
-		GetEntPropVector(client, Prop_Send, "m_vecOrigin", clientPos);
-		for(int target=1; target<=MaxClients; target++)
+		if(Classes_GetByIndex(Client[client].Class, class) && !class.Human && IsFriendly(Client[client].Class, Client[target].Class))
 		{
-			if(target != client)
-			{
-				if(!IsValidClient(target, false) || !Client[client].CanTalkTo[target])
-					continue;
-
-				Client[target].ThinkIsDead[client] = false;
-				if(!IsSpec(target))
-				{
-					if(!class.Human && IsFriendly(Client[client].Class, Client[target].Class))
-					{
-						CPrintToChat(target, "(%t) %s {default}: %s", class.Display, name, msg);
-						continue;
-					}
-
-					if(radio)
-					{
-						static float targetPos[3];
-						GetEntPropVector(target, Prop_Send, "m_vecOrigin", targetPos);
-						if(GetVectorDistance(clientPos, targetPos) > 400)
-						{
-							CPrintToChat(target, "*RADIO* %s {default}: %s", name, msg);
-							continue;
-						}
-					}
-				}
-			}
-			else if(!class.Human)
-			{
-				CPrintToChat(target, "(%t) %s {default}: %s", class.Display, name, msg);
-				continue;
-			}
-
-			CPrintToChat(target, "%s {default}: %s", name, msg);
+			Format(buffer, length, "(%T)", class.Display, target);
+		}
+		else if (Items_Radio(client) > 1)
+		{
+			static float clientPos[3], targetPos[3];
+			GetEntPropVector(client, Prop_Send, "m_vecOrigin", clientPos);
+			GetEntPropVector(target, Prop_Send, "m_vecOrigin", targetPos);
+			if(GetVectorDistance(clientPos, targetPos) > 400)
+				strcopy(buffer, length, "*RADIO*");
 		}
 	}
-	return Plugin_Handled;
 }
 
 public Action Command_MainMenu(int client, int args)

--- a/addons/sourcemod/scripting/scp_sf/natives.sp
+++ b/addons/sourcemod/scripting/scp_sf/natives.sp
@@ -5,6 +5,7 @@ void Native_Setup()
 	CreateNative("SCPSF_StartMusic", Native_StartMusic);
 	CreateNative("SCPSF_StopMusic", Native_StopMusic);
 	CreateNative("SCPSF_CanTalkTo", Native_CanTalkTo);
+	CreateNative("SCPSF_GetChatTag", Native_GetChatTag);
 }
 
 public any Native_GetClientClass(Handle plugin, int numParams)
@@ -92,4 +93,20 @@ public any Native_CanTalkTo(Handle plugin, int numParams)
 		return false;
 
 	return Client[client].CanTalkTo[target];
+}
+
+public any Native_GetChatTag(Handle plugin, int numParams)
+{
+	int client = GetNativeCell(1);
+	if(client<0 || client>=MAXTF2PLAYERS)
+		return;
+
+	int target = GetNativeCell(2);
+	if(target<0 || target>=MAXTF2PLAYERS)
+		return;
+
+	int length = GetNativeCell(4);
+	char[] buffer = new char[length];
+	GetClientChatTag(client, target, buffer, length);
+	SetNativeString(3, buffer, length);
 }


### PR DESCRIPTION
Redsun manages chat messages using `SCPSF_CanTalkTo`, but it's missing tag next to client names. So I added new native `SCPSF_GetChatTag` to allow subplugin to add tag next to client name on its own chat managing. I'm not sure if theres a better name to call this instead of "chat tag". Also renamed `*COMM*` to `*INTERCOM*`.
The only other big difference between SCP and redsun's chat system is name color. SCP always set client name color to red, which redsun doesn't take into account with. Honestly think it's best to just have normal red/blu/grey name color as user should already know which team nearby players are in.