### PR TITLE
Disable friendlyfire between SCPs

### DIFF
--- a/addons/sourcemod/scripting/scp_sf/sdkhooks.sp
+++ b/addons/sourcemod/scripting/scp_sf/sdkhooks.sp
@@ -398,7 +398,12 @@ public Action OnTakeDamage(int victim, int &attacker, int &inflictor, float &dam
 			if(!CvarFriendlyFire.BoolValue && !IsFakeClient(victim))
 				return Plugin_Handled;
 			
-			damage *= 0.4;
+			// do not allow friendlyfire between SCPs
+			if (IsSCP(victim) && IsSCP(attacker))
+				damage = 0.0;
+			else
+				damage *= 0.4;
+				
 			changed = true;
 		}
 


### PR DESCRIPTION
When friendlyfire is enabled, this doesn't make sense and is very easily prone to griefing