### PR TITLE
More karma changes

### DIFF
--- a/addons/sourcemod/scripting/scp_sf/classes.sp
+++ b/addons/sourcemod/scripting/scp_sf/classes.sp
@@ -1113,8 +1113,8 @@ public void Classes_EscapeEscortBonus(int client)
 		
 		if (!IsValidClient(i))
 			continue;
-		
-		if (!IsPlayerAlive(i))
+			
+		if (IsSpec(i))
 			continue;
 		
 		// the disarmer gets a different bonus

--- a/addons/sourcemod/scripting/scp_sf/sdkhooks.sp
+++ b/addons/sourcemod/scripting/scp_sf/sdkhooks.sp
@@ -575,13 +575,14 @@ public void OnTakeDamageAlivePost(int victim, int attacker, int inflictor, float
 
 	// compensate for the other player's karma
 	// don't apply this for friendlyfire damage though
+	// removed: this makes karma too lenient
 	float victimkarmaratio = 1.0;
-	if (!IsFriendly(Client[victim].Class, DamageSavedClass))
-	{
-		float victimkarma = Classes_GetKarma(victim);
-		victimkarmaratio = (victimkarma * 0.01);
-		penaltyamount = RoundFloat(float(penaltyamount) * victimkarmaratio);
-	}
+	//if (!IsFriendly(Client[victim].Class, DamageSavedClass))
+	//{
+	//	float victimkarma = Classes_GetKarma(victim);
+	//	victimkarmaratio = (victimkarma * 0.01);
+	//	penaltyamount = RoundFloat(float(penaltyamount) * victimkarmaratio);
+	//}
 	
 	if ((checked == 2) || ((checked == 0) && IsBadKill(victim, attacker, DamageSavedClass)))
 	{
@@ -600,10 +601,14 @@ public void OnTakeDamageAlivePost(int victim, int attacker, int inflictor, float
 			float karmaMin = CvarKarmaMin.FloatValue;
 			float prevkarma = karma;
 			
+			// lose 5 more karma for friendlyfire kills
+			if (IsFriendly(Client[victim].Class, DamageSavedClass))
+				karmaPoints += 5.0;
+				
 			// hack: this compensates for miniscule precision errors
 			if (karmaPoints > 0.01)
 			{
-				karma -= Client[attacker].KarmaPoints[victim] * victimkarmaratio;
+				karma -= karmaPoints * victimkarmaratio;
 				if (karma < karmaMin)
 					karma = karmaMin;
 


### PR DESCRIPTION
Fixed spectators getting karma escort bonus
Removed penalty scaling by victim karma, it was being exploited and caused confusion
Added +5 karma loss for friendlyfire kills (25 karma loss instead of 20 total) to further discourage it