### PR TITLE
Add scp_insertitem_# relay and update scp_turtle_support.cfg

### DIFF
--- a/addons/sourcemod/configs/scp_sf/maps/scp_turtle_support.cfg
+++ b/addons/sourcemod/configs/scp_sf/maps/scp_turtle_support.cfg
@@ -2251,7 +2251,7 @@
 		"15"	// Minigun
 		{
 			"classname"	"tf_weapon_minigun"
-			"attributes"	"1 ; 0.8 ; 6 ; 0.666667 ; 28 ; 0.5 ; 86 ; 1.2"
+			"attributes"	"1 ; 0.9 ; 6 ; 0.8 ; 28 ; 0.5 ; 86 ; 1.3"
 			"type"		"1"
 			"ammo"		"300"
 			"bullet"	"2"
@@ -2805,7 +2805,7 @@
 			"type"		"5"
 			"hide"		"1"
 			
-			"model"		"models/turtle_attack/redmetal.mdl"
+			"model"		"models/blap19/coins/coin_silver.mdl"
 		
 			"914"		"636"
 			"914-"		"-1"

--- a/addons/sourcemod/configs/scp_sf/maps/scp_turtle_support.cfg
+++ b/addons/sourcemod/configs/scp_sf/maps/scp_turtle_support.cfg
@@ -21,15 +21,16 @@
 			"13"	"scp035"
 			"14"	"scp049"
 			"15"	"scp0492"
-			"16"	"scp096"
-			"17"	"scp106"
-			"18"	"scp173"
-			"19"	"scp939"
-			"20"	"scp9392"
-			"21"	"ht1"
-			"22"	"ht2"
-			"23"	"ht3"
-			"24"	"janitor"
+			"16"	"scp076"
+			"17"	"scp096"
+			"18"	"scp106"
+			"19"	"scp173"
+			"20"	"scp939"
+			"21"	"scp9392"
+			"22"	"ht1"
+			"23"	"ht2"
+			"24"	"ht3"
+			"25"	"janitor"
 		}
 
 		"setup"	// Goes up to 32 players
@@ -154,13 +155,15 @@
 			"set_scp"
 			{
 				"type"	"Gamemode_PresetRandomOnce"	// Only one of this class alive
-				"1" "scp049"
-				"2"	"scp096"
-				"3"	"scp106"
-				"4"	"scp173"
-				"5"	"scp457"
-				"6"	"scp939"
-				"7"	"scp9392"
+				"1"	"scp035"
+				"2" "scp049"
+				"3"	"scp076"
+				"4"	"scp096"
+				"5"	"scp106"
+				"6"	"scp173"
+				"7"	"scp457"
+				"8"	"scp939"
+				"9"	"scp9392"
 			}
 			"set_badguy"
 			{
@@ -963,9 +966,9 @@
 			"class"		"heavy"
 			"model"		"models/hatturtle/hatturtle_heavy.mdl"
 			"modelalt"	"models/player/heavy.mdl"
-			"health"	"200"
+			"health"	"175"
 			"regen"		"1"
-			"speed"		"240"
+			"speed"		"230"
 			"cansprint"	"1"
 			"canpickup"	"1"
 			"group"		"0"
@@ -2239,6 +2242,7 @@
 			"model"		"models/weapons/c_models/c_rocketlauncher/c_rocketlauncher.mdl"
 
 			"func_damage"	"Items_ExplosiveHit"
+			"func_button"    "Items_DisarmerButton"
 
 			"914"		"594"
 			"914-"		"1083"
@@ -2247,7 +2251,7 @@
 		"15"	// Minigun
 		{
 			"classname"	"tf_weapon_minigun"
-			"attributes"	"6 ; 0.666667 ; 28 ; 0.5"
+			"attributes"	"1 ; 0.8 ; 6 ; 0.666667 ; 28 ; 0.5 ; 86 ; 1.2"
 			"type"		"1"
 			"ammo"		"300"
 			"bullet"	"2"
@@ -2256,6 +2260,7 @@
 			"model"		"models/weapons/c_models/c_minigun/c_minigun.mdl"
 
 			"func_damage"	"Items_LogicerHit"
+			"func_button"    "Items_DisarmerButton"
 
 			"914"		"594"
 			"914-"		"594"
@@ -2275,6 +2280,7 @@
 			"model"		"models/workshop/weapons/c_models/c_kingmaker_sticky/c_kingmaker_sticky.mdl"
 
 			"func_damage"	"Items_HeadshotHit"
+			"func_button"    "Items_DisarmerButton"
 
 			"914++"		"425"
 			"914+"		"425"
@@ -2779,7 +2785,7 @@
 		"30089"	// Red Metal
 		{
 			"classname"	"tf_weapon_fists"
-			"attributes"	"881 ; -4 ; 252 ; 0.25 ; 476 ; 0 ; 269 ; 1 ; 62 ; 0.3 ; 64 ; 0.3 ; 66 ; 0.3"
+			"attributes"	"881 ; -4 ; 252 ; 0.25 ; 476 ; 0 ; 269 ; 1 ; 62 ; 0.35 ; 64 ; 0.35 ; 66 ; 0.35 ; 206 ; 0.35"
 			"type"		"5"
 			"hide"		"1"
 			
@@ -2792,14 +2798,28 @@
 			"914--"		"-1"
 		}
 		
+		"636"	// Coin
+		{
+			"classname"	"tf_weapon_fists"
+			"attributes"	"476 ; 0"
+			"type"		"5"
+			"hide"		"1"
+			
+			"model"		"models/turtle_attack/redmetal.mdl"
+		
+			"914"		"636"
+			"914-"		"-1"
+			"914--"		"-1"
+		}
+		
 		"30666"	// Blaster Pistol
 		{
 			"classname"	"tf_weapon_pistol"
-			"attributes"	"2 ; 1.7 ; 4 ; 2 ; 5 ; 1.3 ; 182 ; 2 ; 397 ; 10 ; 647 ; 1 ; 106 ; 0.5"
+			"attributes"	"2 ; 1.8 ; 4 ; 2 ; 5 ; 1.3 ; 182 ; 2 ; 397 ; 10 ; 647 ; 1 ; 106 ; 0.5"
 			"strip"		"1"
 			"type"		"1"
 			"clip"		"24"
-			"ammo"		"25"
+			"ammo"		"24"
 			"bullet"	"7"
 			"class"		"scout"
 			
@@ -2810,16 +2830,17 @@
 			"914--"		"209;773"
 			
 			"func_damage"	"Items_HeadshotHit"
+			"func_button"    "Items_DisarmerButton"
 		}
 		
 		"30665"	// Blaster Rifle
 		{
 			"classname"	"tf_weapon_smg"
-			"attributes"	"2 ; 1.8 ; 4 ; 2 ; 6 ; 0.7 ; 96 ; 8 ; 397 ; 10 ; 647 ; 1 ; 106 ; 0.1"
+			"attributes"	"2 ; 1.9 ; 4 ; 2 ; 6 ; 0.7 ; 96 ; 8 ; 397 ; 10 ; 647 ; 1 ; 106 ; 0.1"
 			"strip"		"1"
 			"type"		"1"
 			"clip"		"50"
-			"ammo"		"50"
+			"ammo"		"100"
 			"bullet"	"2"
 			"class"		"sniper"
 			
@@ -2830,6 +2851,7 @@
 			"914--"		"203;751"
 			
 			"func_damage"	"Items_HeadshotHit"
+			"func_button"    "Items_DisarmerButton"
 		}
 	}
 }

--- a/addons/sourcemod/configs/scp_sf/maps/scp_turtle_support.cfg
+++ b/addons/sourcemod/configs/scp_sf/maps/scp_turtle_support.cfg
@@ -300,6 +300,7 @@
 				"9"	"100"	// Radio
 				"10"	"18"	// 4mag
 				"11"	"14"	// 12ga
+				"12"	"200"	// Energy Cells
 			}
 			"downloads"	// Download table
 			{
@@ -995,6 +996,7 @@
 				"2"	"300"	// 9mm
 				"7"	"100"	// 5mm
 				"9"	"100"	// Radio
+				"12"	"100"
 			}
 		}
 		"ht2"
@@ -1028,9 +1030,10 @@
 			}
 			"ammo"
 			{
-				"2"	"300"	// 9mm
+				"2"	"100"	// 9mm
 				"7"	"100"	// 5mm
 				"9"	"100"	// Radio
+				"12"	"300"
 			}
 		}
 		"ht3"
@@ -1064,9 +1067,10 @@
 			}
 			"ammo"
 			{
-				"2"	"120"	// 9mm
-				"7"	"120"	// 5mm
+				"2"	"100"	// 9mm
+				"7"	"100"	// 5mm
 				"9"	"100"	// Radio
+				"12"	"120"
 			}
 		}
 		"scp035"
@@ -2815,12 +2819,12 @@
 		"30666"	// Blaster Pistol
 		{
 			"classname"	"tf_weapon_pistol"
-			"attributes"	"2 ; 1.8 ; 4 ; 2 ; 5 ; 1.3 ; 182 ; 2 ; 397 ; 10 ; 647 ; 1 ; 106 ; 0.5"
+			"attributes"	"2 ; 1.9 ; 4 ; 2 ; 5 ; 1.3 ; 182 ; 2 ; 397 ; 10 ; 647 ; 1 ; 106 ; 0.5"
 			"strip"		"1"
 			"type"		"1"
 			"clip"		"24"
-			"ammo"		"24"
-			"bullet"	"7"
+			"ammo"		"48"
+			"bullet"	"12"
 			"class"		"scout"
 			
 			"model"		"models/workshop/weapons/c_models/c_invasion_pistol/c_invasion_pistol.mdl"
@@ -2836,12 +2840,12 @@
 		"30665"	// Blaster Rifle
 		{
 			"classname"	"tf_weapon_smg"
-			"attributes"	"2 ; 1.9 ; 4 ; 2 ; 6 ; 0.7 ; 96 ; 8 ; 397 ; 10 ; 647 ; 1 ; 106 ; 0.1"
+			"attributes"	"2 ; 2.1 ; 4 ; 2 ; 6 ; 0.75 ; 96 ; 8 ; 397 ; 10 ; 647 ; 1 ; 106 ; 0.1"
 			"strip"		"1"
 			"type"		"1"
 			"clip"		"50"
 			"ammo"		"100"
-			"bullet"	"2"
+			"bullet"	"12"
 			"class"		"sniper"
 			
 			"model"		"models/workshop/weapons/c_models/c_invasion_sniperrifle/c_invasion_sniperrifle.mdl"

--- a/addons/sourcemod/scripting/scp_sf.sp
+++ b/addons/sourcemod/scripting/scp_sf.sp
@@ -945,6 +945,28 @@ public Action OnRelayTrigger(const char[] output, int entity, int client, float 
 			}
 		}
 	}
+	else if(!StrContains(name, "scp_insertitem_", false))
+	{
+		if(IsValidClient(client))
+		{
+			char buffers[4][6];
+			ExplodeString(name, "_", buffers, sizeof(buffers), sizeof(buffers[]));
+
+			int index = StringToInt(buffers[2]);
+			int active = GetEntPropEnt(client, Prop_Send, "m_hActiveWeapon");
+			
+			if(GetEntProp(active, Prop_Send, "m_iItemDefinitionIndex") == index)
+			{
+				TF2_RemoveItem(client, active);
+				AcceptEntityInput(entity, "FireUser1", client, client);
+				Items_SwitchItem(client, active);
+			}
+			else
+			{
+				AcceptEntityInput(entity, "FireUser2", client, client);
+			}
+		}
+	}
 	return Plugin_Continue;
 }
 

--- a/addons/sourcemod/scripting/scp_sf.sp
+++ b/addons/sourcemod/scripting/scp_sf.sp
@@ -938,6 +938,7 @@ public Action OnRelayTrigger(const char[] output, int entity, int client, float 
 				if(GetEntProp(ent, Prop_Send, "m_iItemDefinitionIndex") == index)
 				{
 					TF2_RemoveItem(client, ent);
+					AcceptEntityInput(entity, "FireUser1", client, client);
 					if(ent == active)
 						Items_SwitchItem(client, ent);
 				}

--- a/addons/sourcemod/translations/it/scp_sf.phrases.txt
+++ b/addons/sourcemod/translations/it/scp_sf.phrases.txt
@@ -1712,7 +1712,7 @@
 	}
 	"info_300666"
 	{
-		"it"		"Arma futuristica a penetrazione infinita. Ricarica veloce"
+		"it"		"Arma futuristica a penetrazione infinita. Ricarica veloce."
 	}
 	"weapon_30665"
 	{

--- a/addons/sourcemod/translations/it/scp_sf.phrases.txt
+++ b/addons/sourcemod/translations/it/scp_sf.phrases.txt
@@ -250,7 +250,7 @@
 	}
 	"desc_dboi"
 	{
-		"it"		"Fuggi dalla struttura. Coopera con i ribelli del Caos. Evita le altre squadre."
+		"it"		"Fuggi dalla struttura.\nCoopera con i ribelli del Caos.\nEvita le altre squadre."
 	}
 	"train_dboi"
 	{
@@ -1780,10 +1780,10 @@
 	}
 	"desc_janitor"
 	{
-		"it"		"Aiuta il personale di Classe D a fuggire.\nCoopera con l'Insurrezione del Caos.\nNeutralizza altri soggetti."
+		"it"		Fuggi dalla struttura.\nCoopera con i ribelli del Caos.\nEvita le altre squadre."
 	}
 	"train_janitor"
 	{
-		"it"		"Devi proteggere la classe D dalle altre squadre.\bAiutali scortandoli dove devono andare.\nSei anche travestito da guardia della struttura."
+		"it"		"Devi fuggire dalla struttura.\nPremi ATTACK, ATTACK2, USE o usa VOICEMENU per interagire con i pulsanti e gli oggetti.\nSei anche travestito da guardia della struttura."
 	}
 }

--- a/addons/sourcemod/translations/scp_sf.phrases.txt
+++ b/addons/sourcemod/translations/scp_sf.phrases.txt
@@ -1780,10 +1780,10 @@
 	}
 	"desc_janitor"
 	{
-		"en"		"Help Class-D Personnel escape.\nCooperate with the Chaos Insurgency.\nNeutralize other subjects."
+		"en"		"Escape from the facility.\nCooperate with the Chaos Insurgency.\nAvoid other teams."
 	}
 	"train_janitor"
 	{
-		"en"		"You need to protect D-classes from other teams.\nHelp them by escorting them where they need to go.\nYou are also disguised as a facility guard."
+		"en"		"You need to escape the facility.\nPress ATTACK, ATTACK2, USE, or use VOICEMENU to interact with buttons and items.\nYou are also disguised as a facility guard."
 	}
 }

--- a/addons/sourcemod/translations/scp_sf.phrases.txt
+++ b/addons/sourcemod/translations/scp_sf.phrases.txt
@@ -1706,13 +1706,21 @@
 
 	// Turtle Support
 
+	"weapon_636"
+	{
+		"en"		"Coin"
+	}
+	"info_636"
+	{
+		"en"		"Worth 25 cents."
+	}
 	"weapon_30666"
 	{
 		"en"		"Blaster Pistol"
 	}
 	"info_300666"
 	{
-		"en"		"Futuristic weapon with infinite penetration. Fast reload"
+		"en"		"Futuristic weapon with infinite penetration. Fast reload."
 	}
 	"weapon_30665"
 	{


### PR DESCRIPTION
Adds scp_insertitem_# which differs from scp_removeitem_# in that:

- You need to hold the item to interact with the relay
- Doesn't remove all items at once

Fires FireUser1 if correct item held
Fires FireUser2 if wrong item held

Also fires FireUser1 for scp_remove_item_# for every item found in the inventory
